### PR TITLE
Patch 1

### DIFF
--- a/1.36/Dockerfile
+++ b/1.36/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && rm -rf /emsdk_portable \
     && rm -rf /emscripten/tests \
     && rm -rf /emscripten/site \
-    && for prog in em++ em-config emar emcc emconfigure emmake emranlib emrun emscons; do \
+    && for prog in em++ em-config emar emcc emconfigure emmake emranlib emrun emscons emcmake; do \
            ln -sf /emscripten/$prog /usr/local/bin; done \
     && apt-get -y --purge remove curl git-core build-essential gcc \
     && apt-get -y clean \

--- a/1.36/Dockerfile
+++ b/1.36/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:latest
 MAINTAINER Vilibald Wanča (wvi@apiary.io)
 
-ENV EMCC_SDK_VERSION 1.36.7
+ENV EMCC_SDK_VERSION 1.36.11
 ENV EMCC_SDK_ARCH 32
 
 WORKDIR /


### PR DESCRIPTION
Hello,

I find this docker image very useful for needs of my toy project. However image for 1.36  is little outdated compared to current master branch in emscripten.

This pull request updates the version to most recent tag (17 days ago) and also fixes a missing symlink.

Additionally, is there any chance to make automatic builds out of this somehow? (_probably open source CI services such as travis would timeout while compiling from scratch but I wonder if you tried it_).
