### PR TITLE
Add Binaryen for WebAssembly support

### DIFF
--- a/1.37/Dockerfile
+++ b/1.37/Dockerfile
@@ -1,19 +1,20 @@
 FROM debian:latest
 MAINTAINER Vilibald Wanča (wvi@apiary.io)
 
-ENV EMCC_SDK_VERSION 1.37.10
+ENV EMCC_SDK_VERSION 1.37.15
 ENV EMCC_SDK_ARCH 32
+ENV EMCC_BINARYEN_VERSION 1.37.14
 
 WORKDIR /
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates build-essential curl git-core openjdk-7-jre-headless python \
-    && apt-mark hold openjdk-7-jre-headless \
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg ca-certificates build-essential curl git-core openjdk-8-jre-headless python \
+    && apt-mark hold openjdk-8-jre-headless \
     && apt-mark hold make \
     && curl -Os https://cmake.org/files/v3.6/cmake-3.6.1.tar.gz \
     && tar xf cmake-3.6.1.tar.gz \
     && cd cmake-3.6.1 && ./configure && make && make install && cd ..\
     && rm -rf cmake* \
-    && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get install -y nodejs \
     && curl https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz > emsdk-portable.tar.gz \
     && tar xzf emsdk-portable.tar.gz \
@@ -21,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && cd emsdk-portable \
     && ./emsdk update \
     && ./emsdk install --build=MinSizeRel sdk-tag-$EMCC_SDK_VERSION-${EMCC_SDK_ARCH}bit \
+    && ./emsdk install --build=MinSizeRel binaryen-tag-${EMCC_BINARYEN_VERSION}-${EMCC_SDK_ARCH}bit \
 \
     && mkdir -p /clang \
     && cp -r /emsdk-portable/clang/tag-e$EMCC_SDK_VERSION/build_tag-e${EMCC_SDK_VERSION}_${EMCC_SDK_ARCH}/bin /clang \
@@ -29,13 +31,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && mkdir -p /emscripten \
     && cp -r /emsdk-portable/emscripten/tag-$EMCC_SDK_VERSION/* /emscripten \
     && cp -r /emsdk-portable/emscripten/tag-${EMCC_SDK_VERSION}_${EMCC_SDK_ARCH}bit_optimizer/optimizer /emscripten/ \
-    && echo "import os\nLLVM_ROOT='/clang/bin/'\nNODE_JS='nodejs'\nEMSCRIPTEN_ROOT='/emscripten'\nEMSCRIPTEN_NATIVE_OPTIMIZER='/emscripten/optimizer'\nSPIDERMONKEY_ENGINE = ''\nV8_ENGINE = ''\nTEMP_DIR = '/tmp'\nCOMPILER_ENGINE = NODE_JS\nJS_ENGINES = [NODE_JS]\n" > ~/.emscripten \
+    && mkdir -p /binaryen \
+    && cp -r /emsdk-portable/binaryen/tag-${EMCC_BINARYEN_VERSION}_${EMCC_SDK_ARCH}bit_binaryen/* /binaryen \
+    && echo "import os\nLLVM_ROOT='/clang/bin/'\nNODE_JS='nodejs'\nEMSCRIPTEN_ROOT='/emscripten'\nEMSCRIPTEN_NATIVE_OPTIMIZER='/emscripten/optimizer'\nSPIDERMONKEY_ENGINE = ''\nV8_ENGINE = ''\nTEMP_DIR = '/tmp'\nCOMPILER_ENGINE = NODE_JS\nJS_ENGINES = [NODE_JS]\nBINARYEN_ROOT = '/binaryen/'\n" > ~/.emscripten \
     && rm -rf /emsdk-portable \
     && rm -rf /emscripten/tests \
     && rm -rf /emscripten/site \
+    && rm -rf /binaryen/src /binaryen/lib /binaryen/CMakeFiles \
     && for prog in em++ em-config emar emcc emconfigure emmake emranlib emrun emscons emcmake; do \
            ln -sf /emscripten/$prog /usr/local/bin; done \
-    && apt-get -y --purge remove curl git-core build-essential gcc \
+    && apt-get -y --purge remove gnupg curl git-core build-essential gcc \
     && apt-get -y clean \
     && apt-get -y autoclean \
     && apt-get -y autoremove \
@@ -45,6 +50,7 @@ RUN emcc --version \
     && printf '#include <iostream>\nint main(){std::cout<<"HELLO"<<std::endl;return 0;}' > test.cpp \
     && em++ -O2 test.cpp -o test.js && nodejs test.js \
     && em++ test.cpp -o test.js && nodejs test.js \
+    && em++ -s WASM=1 test.cpp -o test.js && nodejs test.js \
     && cd / \
     && rm -rf /tmp/emscripten_test \
 


### PR DESCRIPTION
Hi,

This commit is used for add WebAssembly support by add Binaryen into the install script.

The reason of version update of openjdk is because openjdk 7 is not avaiable on the latest debian, so openjdk 8 must be used. Add gnupg is because this package is removed in lastest debian but it's required by curl.