### PR TITLE
Provide status message once done

### DIFF
--- a/1.37/Dockerfile
+++ b/1.37/Dockerfile
@@ -49,6 +49,7 @@ RUN emcc --version \
     && em++ -s WASM=1 test.cpp -o test.js && nodejs test.js \
     && cd / \
     && rm -rf /tmp/emscripten_test \
+    && echo "All done."
 
 VOLUME ["/src"]
 WORKDIR /src


### PR DESCRIPTION
Otherwise, the empty continuation line will error
in future docker releases.